### PR TITLE
Fix: moved alert to success of the await function

### DIFF
--- a/script.js
+++ b/script.js
@@ -680,15 +680,16 @@ setTimesFromURL();
       async function writeURLtoClipboard(text) {
         try {
           await navigator.clipboard.writeText(text);
+          alert(
+            "Sendable times URL copied to your clipboard and ready to send to your colleague."
+          );
         } catch (error) {
           console.log("Something went wrong", error);
         }
       }
       writeURLtoClipboard(sendableURL);
 
-      alert(
-        "Sendable times URL copied to your clipboard and ready to send to your colleague."
-      );
+      
       $("input").remove(".dummy");
     };
     createURL();


### PR DESCRIPTION
This is for #8 - I could reliably create the problem where I am unable to copy the url, but only on the hosted version, it worked perfectly fine on my localhost. With the asynchronous nature of the call you made, it seemed better to pull the confirmation alert in the try function.

The error suggested that the DOM didn't have focus and the code suggests and the behaviour on site suggests that the alert has focus

Flow before:

1) Try to copy and await
2) Show alert
3) Result of await comes in but failed, because the alert had focus (in other words the alert would always show)

New Flow:

1) Try to copy and await
2) Result of await comes in, if successful will show alert
Problem: if not successful nothing was done

See https://www.otzberg.net/tsc for demo of the fix.

Suggestion:
Maybe have a success div and write both URL and success message there, also gives you a place for an error